### PR TITLE
Add support for ActionJSON

### DIFF
--- a/IDL/ems_grpc.proto
+++ b/IDL/ems_grpc.proto
@@ -39,7 +39,7 @@ service gRPCExec {
 // Exec commands
     rpc ShowCmdTextOutput(ShowCmdArgs) returns(stream ShowCmdTextReply) {};
     rpc ShowCmdJSONOutput(ShowCmdArgs) returns(stream ShowCmdJSONReply) {};
-
+    rpc ActionJSON(ActionJSONArgs) returns(stream ActionJSONReply) {};
 
 }
 
@@ -148,4 +148,13 @@ message ShowCmdJSONReply {
     string errors = 3;
 }
 
+message ActionJSONArgs {
+	int64 ReqId = 1;
+	string yangpathjson = 2;
+}
 
+message ActionJSONReply {
+	int64 ResReqId = 1;
+	string yangjson = 2;
+	string errors = 3;
+}


### PR DESCRIPTION
Taken from https://www.cisco.com/c/en/us/td/docs/iosxr/ncs5500/programmability/73x/b-programmability-cg-ncs5500-73x/use-grpc-protocol-to-define-network-operation-with-data-models.html